### PR TITLE
feat: switch all tests to janus-idp helm chart

### DIFF
--- a/.github/workflows/showcase-e2e-test-iks.yaml
+++ b/.github/workflows/showcase-e2e-test-iks.yaml
@@ -3,9 +3,9 @@ name: Showcase-e2e-test-iks
 on:
   push:
     branches: [ main ]
-  
+
 jobs:
-  test: 
+  test:
     name: Run Cypress Tests for Backstage
     strategy:
       fail-fast: true
@@ -13,7 +13,7 @@ jobs:
           os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
-    
+
     steps:
     - name: Check out code into the working directory
       uses: actions/checkout@v3
@@ -35,21 +35,22 @@ jobs:
           kubectl config current-context
 
     - name: Install wait-on
-      run: npm install -g wait-on 
+      run: npm install -g wait-on
       shell: bash
-    
+
     - name: Install Backstage helm chart
       uses: WyriHaximus/github-action-helm3@v3
       with:
         exec: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add backstage https://backstage.github.io/charts
-          helm repo update
-          helm install -n backstage backstage backstage/backstage -f ./helm/values-k8s-ingress.yaml
-            
+          helm repo add janus-idp https://janus-idp.github.io/helm-backstage
+
+          helm install -n backstage backstage janus-idp/backstage -f ./helm/values-k8s-ingress.yaml
+
     # - name: Wait until Showcase app is up and running
     #   run: |
-    #     wait-on http://janusidp.test.com --httpTimeout 50000 && curl http://janusidp.test.com 
+    #     wait-on http://janusidp.test.com --httpTimeout 50000 && curl http://janusidp.test.com
     - name: Run port-forward
       run: |
         sleep 45s
@@ -58,7 +59,7 @@ jobs:
     - name: Run tests
       uses: cypress-io/github-action@v5
       with:
-        browser: chrome  
+        browser: chrome
         wait-on: 'http://localhost:7007'
         wait-on-timeout: 120
         working-directory: app-test

--- a/.github/workflows/showcase-e2e-test-minikube.yaml
+++ b/.github/workflows/showcase-e2e-test-minikube.yaml
@@ -3,9 +3,9 @@ name: Showcase-e2e-test-minikube
 on:
   push:
     branches: [ main ]
-    
+
 jobs:
-  test: 
+  test:
     name: Run Cypress Tests for Backstage
     strategy:
       fail-fast: true
@@ -13,44 +13,46 @@ jobs:
           os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
-    
+
     steps:
     - name: Check out code into the working directory
       uses: actions/checkout@v3
-    
+
     - name: Start minikube
       id: minikube
       uses: medyagh/setup-minikube@master
       with:
           driver: docker
           addons: ingress
-    
+
     # - name: Obtain minikube ip
     #   id: minikube-ip
     #   shell: bash
     #   run:  |
     #     echo "MINIKUBE_IP=$(minikube ip)" >> "$GITHUB_OUTPUT"
     #     kubectl get pods -A
-    
+
     # - name: Add backstage host name into /etc/hosts
     #   run: |
     #     sudo echo "${{ steps.minikube-ip.outputs.MINIKUBE_IP }} janusidp.test.com" | sudo tee -a /etc/hosts
-    
+
     - name: Install wait-on
-      run: npm install -g wait-on 
+      run: npm install -g wait-on
       shell: bash
-    
+
     - name: Install Backstage helm chart
       uses: WyriHaximus/github-action-helm3@v3
       with:
         exec: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add backstage https://backstage.github.io/charts
-          helm install -n backstage --create-namespace backstage backstage/backstage -f ./helm/values-k8s-ingress.yaml
-            
+          helm repo add janus-idp https://janus-idp.github.io/helm-backstage
+
+          helm install -n backstage --create-namespace backstage janus-idp/backstage -f ./helm/values-k8s-ingress.yaml
+
     # - name: Wait until Showcase app is up and running
     #   run: |
-    #     wait-on http://janusidp.test.com --httpTimeout 50000 && curl http://janusidp.test.com 
+    #     wait-on http://janusidp.test.com --httpTimeout 50000 && curl http://janusidp.test.com
     - name: Run port-forward
       run: |
         sleep 45s
@@ -59,7 +61,7 @@ jobs:
     - name: Run tests
       uses: cypress-io/github-action@v5
       with:
-        browser: chrome  
+        browser: chrome
         wait-on: 'http://localhost:7007'
         wait-on-timeout: 120
         working-directory: app-test

--- a/.github/workflows/showcase-e2e-test-openshift.yaml
+++ b/.github/workflows/showcase-e2e-test-openshift.yaml
@@ -3,9 +3,9 @@ name: Showcase-e2e-test-openshift
 on:
   push:
     branches: [ main ]
-  
+
 jobs:
-  test: 
+  test:
     name: Run Cypress Tests for Backstage
     strategy:
       fail-fast: true
@@ -13,7 +13,7 @@ jobs:
           os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
-    
+
     steps:
     - name: Check out code into the working directory
       uses: actions/checkout@v3
@@ -39,9 +39,9 @@ jobs:
           oc project ${{ secrets.OPENSHIFT_NAMESPACE }}
 
     - name: Install wait-on
-      run: npm install -g wait-on 
+      run: npm install -g wait-on
       shell: bash
-    
+
     - name: Install Backstage helm chart
       uses: WyriHaximus/github-action-helm3@v3
       with:
@@ -49,9 +49,9 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add backstage https://backstage.github.io/charts
           helm repo add janus-idp https://janus-idp.github.io/helm-backstage
-          helm repo update
+
           helm upgrade -i backstage janus-idp/backstage -f ./helm/values-openshift-route.yaml -n ${{ secrets.OPENSHIFT_NAMESPACE }}
-          
+
     - name: Run port-forward
       run: |
         sleep 45s
@@ -60,7 +60,7 @@ jobs:
     - name: Run tests
       uses: cypress-io/github-action@v5
       with:
-        browser: chrome 
+        browser: chrome
         wait-on: 'http://localhost:7007'
         wait-on-timeout: 120
         working-directory: app-test

--- a/helm/values-k8s-ingress.yaml
+++ b/helm/values-k8s-ingress.yaml
@@ -1,13 +1,21 @@
-backstage:
-  extraEnvVars:
-    - name: 'APP_CONFIG_app_baseUrl'
-      value: 'http://{{ .Values.ingress.host }}'
-    - name: 'APP_CONFIG_backend_baseUrl'
-      value: 'http://{{ .Values.ingress.host }}'
-    - name: 'APP_CONFIG_backend_cors_origin'
-      value: 'http://{{ .Values.ingress.host }}`'
- 
-ingress:
-  enabled: true
-  host: janusidp.test.com
+upstream:
+  backstage:
+    extraEnvVars:
+      - name: 'APP_CONFIG_app_baseUrl'
+        value: 'http://{{ .Values.ingress.host }}'
+      - name: 'APP_CONFIG_backend_baseUrl'
+        value: 'http://{{ .Values.ingress.host }}'
+      - name: 'APP_CONFIG_backend_cors_origin'
+        value: 'http://{{ .Values.ingress.host }}`'
 
+  ingress:
+    enabled: true
+    host: janusidp.test.com
+
+  postgresql:
+    primary:
+      persistence:
+        enabled: false
+
+route:
+  enabled: false

--- a/helm/values-minikube-ingress.yaml
+++ b/helm/values-minikube-ingress.yaml
@@ -1,13 +1,21 @@
-backstage:
-  extraEnvVars:
-    - name: 'APP_CONFIG_app_baseUrl'
-      value: 'http://{{ .Values.ingress.host }}'
-    - name: 'APP_CONFIG_backend_baseUrl'
-      value: 'http://{{ .Values.ingress.host }}'
-    - name: 'APP_CONFIG_backend_cors_origin'
-      value: 'http://{{ .Values.ingress.host }}`'
- 
-ingress:
-  enabled: true
-  host: janusidp.test.com
+upstream:
+  backstage:
+    extraEnvVars:
+      - name: 'APP_CONFIG_app_baseUrl'
+        value: 'http://{{ .Values.ingress.host }}'
+      - name: 'APP_CONFIG_backend_baseUrl'
+        value: 'http://{{ .Values.ingress.host }}'
+      - name: 'APP_CONFIG_backend_cors_origin'
+        value: 'http://{{ .Values.ingress.host }}`'
 
+  ingress:
+    enabled: true
+    host: janusidp.test.com
+
+  postgresql:
+    primary:
+      persistence:
+        enabled: false
+
+route:
+  enabled: false

--- a/helm/values-openshift-route.yaml
+++ b/helm/values-openshift-route.yaml
@@ -7,13 +7,8 @@ upstream:
         value: "https://{{ .Values.global.host }}"
       - name: "APP_CONFIG_backend_cors_origin"
         value: "https://{{ .Values.global.host }}"
-  ingress:
-    enabled: false
 route:
-  enabled: true
   host: "{{ .Values.global.host }}"
-  tls:
-    enabled: true
 
 global:
   host: janusidp.test.com


### PR DESCRIPTION
cc @josephca 

This should provide valid helm values for all platforms. I'm not sure if we have persistent storage in minikube/iks, so I've disabled postgres PVC request there.

PTAL