### PR TITLE
Add OWNERS file for onboarding to OpenShift CI

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - josephca
+  - rnapoles-rh
+approvers:
+  - josephca
+  - rnapoles-rh


### PR DESCRIPTION
This PR is to upload the required place-holder files to onboard showcase-e2e repository to the OpenShift CI test framework. The files don't include any meaningful tests yet.