### PR TITLE
chore: add blank issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.md
+++ b/.github/ISSUE_TEMPLATE/blank.md
@@ -1,0 +1,5 @@
+---
+name: Blank Template
+about: Create a blank issue
+labels: [status/triage]
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,13 +1,15 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: kind/bug
+labels: [kind/bug, status/triage]
 ---
 
 ## Describe the bug
+
 A clear and concise description of what the bug is.
 
 ## To Reproduce
+
 Steps to reproduce the behavior:
 
 1. Go to '...'
@@ -16,10 +18,13 @@ Steps to reproduce the behavior:
 4. See error
 
 ## Expected behavior
+
 A clear and concise description of what you expected to happen.
 
 ## Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
 ## Additional context
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Janus IDP Community Slack
+    url: https://join.slack.com/t/janus-idp/shared_invite/zt-1pxtehxom-fCFtF9rRe3vFqUiFFeAkmg
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,26 +1,33 @@
 ---
 name: Epic
 about: Create an epic
-labels: kind/epic
+labels: [kind/epic, status/triage]
 ---
 
 ## Goal
+
 A clear and concise description of the goal of this epic.
 
 ## What problem does this solve? Please describe.
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 ## Use cases
+
 A clear and concise description of persona and associated use cases that need to be supported.
 
 ## Acceptance criteria
+
 A clear and concise list of acceptance criteria, noting what will be delivered as part of this epic. This will help identify associated testing, documentation and support needs.
+
 - [ ] items
-   - [ ] item 1
-   - [ ] item 2
+  - [ ] item 1
+  - [ ] item 2
 
 ## Additional context
+
 Add any other context or screenshots about the feature request here.
 
 ## Issues in Epic
+
 - [ ] tbd

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,17 +1,21 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: kind/feature
+labels: [kind/feature, status/triage]
 ---
 
 ## Is your feature request related to a problem? Please describe.
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 ## Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
 ## Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
 ## Additional context
+
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -1,17 +1,21 @@
 ---
 name: Report vulnerability
 about: There's a security problem that requires our immediate attention
-labels: kind/security
+labels: [kind/security, status/triage]
 ---
 
 ## Describe how is our service vulnerable
+
 A clear and concise description of what the problem is.
 
 ## Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
 ## Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
 ## Additional context
+
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
### Description
Updated the existing issue templates to also use the `status/triage` label.
Removed the ability for users to create blank issues in favor of creating a blank issue template to enforce the usage of status/triage for all issues.

### Which issue(s) does this PR fix
Fixes #31 