### PR TITLE
Run manually started test without checking files

### DIFF
--- a/.ibm/pipelines/functions.sh
+++ b/.ibm/pipelines/functions.sh
@@ -33,6 +33,12 @@ EOF
 
 skip_if_only() {
     echo "Checking if tests need to be executed..."
+
+    if [ "$IBM_MANUAL_JOB" == "true" ]; then
+        echo "This job was manually started. Continue the tests."
+        return
+    fi
+
     NAMES=$(git diff --merge-base --name-only main)
     for change in ${NAMES}; do
         skip $change


### PR DESCRIPTION
Starting manual test is skipped by not finding any file changes compared to the 'main' branch. Fix it to run manual test always. 